### PR TITLE
Add support for containerd runtime (GKE COS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ This is the script `insert-ca.sh` that will be used in the Docker image:
 #!/bin/bash
 
 cp /myCA.pem /mnt/etc/ssl/certs
+
 nsenter --target 1 --mount update-ca-certificates
-nsenter --target 1 --mount systemctl restart docker
+
+nsenter --target 1 --mount bash -c "systemctl is-active --quiet docker && systemctl restart docker"
+nsenter --target 1 --mount bash -c "systemctl is-active --quiet containerd && systemctl restart containerd"
 ```
 Now build and push the image to GCR:
 ```

--- a/custom-cert/insert-ca.sh
+++ b/custom-cert/insert-ca.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
 cp /myCA.pem /mnt/etc/ssl/certs
+
 nsenter --target 1 --mount update-ca-certificates
-nsenter --target 1 --mount systemctl restart docker
+
+nsenter --target 1 --mount bash -c "systemctl is-active --quiet docker && echo 'Restarting docker' && systemctl restart docker"
+nsenter --target 1 --mount bash -c "systemctl is-active --quiet containerd && echo 'Restarting containerd' && systemctl restart containerd"
+
+# NOTE: After the CRI restarts subsequent logs may not be visible, however the subsequent commands should
+# still have run. You can verify with something like:
+# touch /mnt/etc/completed.txt
+echo "complete"
+


### PR DESCRIPTION
Add support for containerd runtime by conditionally restarting docker/containerd services if they are active. Tested on GKE with Node image type `Container-Optimized OS with Containerd (cos_containerd)` and Node version `1.21.5-gke.1302`.